### PR TITLE
Simply the awk code and add a safeguard to xargs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/app
 ENV CGO_ENABLED=0
 
 COPY go.mod go.sum ./
-RUN go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs go get
+RUN go mod graph | awk '$1 !~ /@/ { print $2 }' | xargs -r go get
 
 COPY main.go ./
 RUN go build -o /go/bin/app

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There is an [open issue](https://github.com/golang/go/issues/27719) but until it
 COPY go.mod go.sum ./
 
 # Add this line before `go build`
-RUN go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs go get
+RUN go mod graph | awk '$1 !~ /@/ { print $2 }' | xargs -r go get
 ```
 
 Full Dockerfile example: [./Dockerfile](./Dockerfile)
@@ -21,7 +21,7 @@ Full Dockerfile example: [./Dockerfile](./Dockerfile)
 
 I used `time` to measure how long it took to build a fresh docker image with `--no-cache` and then changed the main.go file by adding a comment so Docker would run the `go build` step again while keeping the preceeding cached docker layers. 
 
-#### With `go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs go get` dependency cache:
+#### With `go mod graph | awk '$1 !~ /@/ { print $2 }' | xargs -r go get` dependency cache:
 
 ```
 # Fresh build with no cache:


### PR DESCRIPTION
Previously, `go get` would return an error when the project has no dependencies. Adding the `-r` (or `--no-run-if-empty`) option to xargs fixes this by not invoking the `go get` command when the input is empty. The option is a GNU extension, thus not portable. But, as Docker is typically used to build Linux containers, this may not be a problem.